### PR TITLE
Fix anchor closing tag in redirect layout

### DIFF
--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -9,8 +9,8 @@
 
 <body>
     <h1>Redirecting...</h1>
-    <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
-            <script>location = '{{ page.redirect_to }}'</script>
+    <a href="{{ page.redirect_to }}">Click here if you are not redirected.</a>
+    <script>location = '{{ page.redirect_to }}'</script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- fix anchor closing tag in `_layouts/redirected.html`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eccfe8948324b375a583c9a39457